### PR TITLE
Add manage_repo param

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,20 @@ In other words, when there are no pre-existing etcd instances.
 The `server` key will need to be manually deleted from `/etc/rancher/rke2/config.yaml` on one (and only one) node and the `rke2-server` service restarted.
 While this key could be knocked on a single node via hiera, if the node without the `server` key is ever re-provisioned, it would create a new standalone cluster instance which is detached from the existing etcd instances.
 
+### Managing repositories outside the module
+
+Set `manage_repo: false` to disable the module's yum repository management.
+This is useful when repositories are already configured by another module,
+a profile, or an external tool (e.g. Spacewalk / Katello / subscription-manager).
+
+```yaml
+rke2::manage_repo: false
+```
+
+When `manage_repo` is `false`, the module will not create or modify any
+`yumrepo` resources.  The repositories must already be present and enabled
+before the RKE2 packages can be installed.
+
 ## Reference
 
 See [REFERENCE](REFERENCE.md)

--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -51,6 +51,7 @@ The following parameters are available in the `rke2` class:
 * [`config`](#-rke2--config)
 * [`version`](#-rke2--version)
 * [`versionlock`](#-rke2--versionlock)
+* [`manage_repo`](#-rke2--manage_repo)
 
 ##### <a name="-rke2--node_type"></a>`node_type`
 
@@ -107,4 +108,14 @@ Data type: `Boolean`
 Create a yum versionlock for the installed rke2 package(s).
 
 Default value: `false`
+
+##### <a name="-rke2--manage_repo"></a>`manage_repo`
+
+Data type: `Boolean`
+
+When true (default), the module manages the RKE2 yum repositories.
+Set to false to disable repo management and configure repositories
+outside this module (e.g. via a profile or a separate Puppet module).
+
+Default value: `true`
 

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -34,6 +34,11 @@
 # @param versionlock
 #   Create a yum versionlock for the installed rke2 package(s).
 #
+# @param manage_repo
+#   When true (default), the module manages the RKE2 yum repositories.
+#   Set to false to disable repo management and configure repositories
+#   outside this module (e.g. via a profile or a separate Puppet module).
+#
 class rke2 (
   Enum['server','agent'] $node_type,
   String[1] $release_series,
@@ -43,8 +48,13 @@ class rke2 (
   Optional[Hash] $config = undef,
   Optional[String[1]] $version = undef,
   Boolean $versionlock = false,
+  Boolean $manage_repo = true,
 ) {
-  contain rke2::repo
+  if $manage_repo {
+    contain rke2::repo
+    Class['rke2::repo'] ~> Class['rke2::install']
+  }
+
   contain rke2::install
   contain rke2::service
 
@@ -56,7 +66,6 @@ class rke2 (
     ~> Class['rke2::service']
   }
 
-  Class['rke2::repo']
-  ~> Class['rke2::install']
+  Class['rke2::install']
   ~> Class['rke2::service']
 }

--- a/spec/classes/rke2_spec.rb
+++ b/spec/classes/rke2_spec.rb
@@ -8,6 +8,19 @@ describe 'rke2' do
       let(:facts) { os_facts }
 
       it { is_expected.to compile }
+
+      it { is_expected.to contain_class('rke2::repo') }
+      it { is_expected.to contain_class('rke2::install') }
+      it { is_expected.to contain_class('rke2::service') }
+
+      context 'with manage_repo => false' do
+        let(:params) { { manage_repo: false } }
+
+        it { is_expected.to compile }
+        it { is_expected.not_to contain_class('rke2::repo') }
+        it { is_expected.to contain_class('rke2::install') }
+        it { is_expected.to contain_class('rke2::service') }
+      end
     end
   end
 end


### PR DESCRIPTION
I've added a manage_repo param. Default behaivor is unchanged.

### Managing repositories outside the module

Set `manage_repo: false` to disable the module's yum repository management.
This is useful when repositories are already configured by another module,
a profile, or an external tool (e.g. Spacewalk / Katello / subscription-manager).

```yaml
rke2::manage_repo: false
```

When `manage_repo` is `false`, the module will not create or modify any
`yumrepo` resources.  The repositories must already be present and enabled
before the RKE2 packages can be installed.